### PR TITLE
Change servlet response to 200 with a body, fix choking hub action queue

### DIFF
--- a/org.openhab.binding.smartthings/src/main/java/org/openhab/binding/smartthings/internal/SmartthingsServlet.java
+++ b/org.openhab.binding.smartthings/src/main/java/org/openhab/binding/smartthings/internal/SmartthingsServlet.java
@@ -140,8 +140,14 @@ public class SmartthingsServlet extends HttpServlet {
             logger.error("Smartthing servlet recieved a path that is not supported {}", pathParts[0]);
         }
 
-        // Return an http-204 - No response
-        resp.setStatus(HttpServletResponse.SC_NO_CONTENT);
+        // Respond with 200 / "OK" on success.
+        // responses with an empty body will choke response processing on the
+        // hub, resulting in a 6-8s delay in all message processing, as the hub
+        // only seems to dispatch one HubEvent at a time.
+        resp.setStatus(HttpServletResponse.SC_OK);
+        resp.getWriter().write("OK");
+        resp.getWriter().flush();
+        resp.getWriter().close();
         return;
     }
 


### PR DESCRIPTION
My HubActions were being delayed by 6-8s each and I couldn't find any documentation on why that is the case.

It appears that the HubAction queue will choke for a timeout of 6-8s~ if a http action doesn't return a body (or possibly on the 204 http code, I didn't test them separately.) And since it also seems that there's a singular HubAction queue that will process them in sequence, the whole thing just chokes if lots of events come through (and by lots, I mean anything more than one event every 10 seconds.)

This fixes that.