### PR TITLE
Smartthings config notice near beginning.

### DIFF
--- a/org.openhab.binding.smartthings/README.md
+++ b/org.openhab.binding.smartthings/README.md
@@ -17,7 +17,9 @@ Please test with your devices. When (I won't even say if) you find one that does
 
 ## Discovery
 
-Discovery allows OpenHAB to examine a binding and automatically find the Things available on binding. Discovery is supported and does work but needs more testing.
+Discovery allows OpenHAB to examine a binding and automatically find the Things available on binding. Discovery is supported and does work but needs more testing. 
+
+Remember to follow the [Smartthings Configuration insturction](SmartthingsInstallation.md) below before running discovery. 
 
 Discovery is not run automatically on startup. Therefore to run the discovery process perform the following:
 


### PR DESCRIPTION
Rather than just complaining I tried to make it a bit clearer. For those of us beta testing, we know how to install a binding so are likely to jump straight to the discovery section at the beginning of the readme. So I just added a note to remind people to follow the instructions below to set up the Smartthings hub.